### PR TITLE
Fix string split to be same as python's split

### DIFF
--- a/src/main/scala/ast/BinaryOpNodes.scala
+++ b/src/main/scala/ast/BinaryOpNodes.scala
@@ -553,10 +553,19 @@ case class PyStringSplit(val lhs: PyStringNode, val rhs: PyStringNode) extends B
 {
   override protected val parenless: Boolean = true
   override lazy val code: String = lhs.parensIfNeeded + ".split(" + rhs.code + ")"
-
+  private def split_python(s : String, sep: String): Array[String] = {
+    var rs = s.split(sep)
+    // scala split keep first empty, unless it is the only character
+    if (s.startsWith(sep) && s.length == 1)
+      rs = "" +: rs
+    // scala split remove last empty field
+    if (s.endsWith(sep))
+      rs = rs :+ ""
+    rs
+  }
   override def doOp(l: Any, r: Any): Option[Iterable[String]] = (l, r) match {
     case (_, "") => None
-    case (l: String, r: String) => Some(l.split(r).toList)
+    case (l: String, r: String) => Some(split_python(l, r).toList)
     case _ => wrongType(l, r)
   }
 

--- a/src/test/scala/PyASTNodeTests.scala
+++ b/src/test/scala/PyASTNodeTests.scala
@@ -1070,7 +1070,38 @@ class PyASTNodeTests extends JUnitSuite {
   @Test def stringReplaceNode(): Unit = ()
 
   // List Operations
-  @Test def stringSplitNode(): Unit = ()
+  @Test def stringSplitNode(): Unit = {
+    // Test split is same as python's split
+    val sep = "-"
+
+    val s1 = "a-b-c-d"
+    val split1 = new PyStringSplit(PyStringLiteral(s1, 1), PyStringLiteral(sep, 1))
+    assertEquals(Some(List("a", "b", "c", "d")), split1.doOp(s1, sep))
+
+    val s2 = "a-b-c-d-"
+    val split2 = new PyStringSplit(PyStringLiteral(s2, 1), PyStringLiteral(sep, 1))
+    assertEquals(Some(List("a", "b", "c", "d", "")), split2.doOp(s2, sep))
+
+    val s3 = "-a-b-c-d"
+    val split3 = new PyStringSplit(PyStringLiteral(s3, 1), PyStringLiteral(sep, 1))
+    assertEquals(Some(List("", "a", "b", "c", "d")), split3.doOp(s3, sep))
+
+    val s4 = "-"
+    val split4 = new PyStringSplit(PyStringLiteral(s4, 1), PyStringLiteral(sep, 1))
+    assertEquals(Some(List("", "")), split4.doOp(s4, sep))
+
+    val s5 = "-a-b-c-d-"
+    val split5 = new PyStringSplit(PyStringLiteral(s5, 1), PyStringLiteral(sep, 1))
+    assertEquals(Some(List("", "a", "b", "c", "d", "")), split5.doOp(s5, sep))
+
+    val s6 = "-a"
+    val split6 = new PyStringSplit(PyStringLiteral(s6, 1), PyStringLiteral(sep, 1))
+    assertEquals(Some(List("", "a")), split6.doOp(s6, sep))
+
+    val s7 = "-a-"
+    val split7 = new PyStringSplit(PyStringLiteral(s7, 1), PyStringLiteral(sep, 1))
+    assertEquals(Some(List("", "a", "")), split7.doOp(s7, sep))
+  }
   @Test def stringJoinNode(): Unit = ()
   @Test def stringStepListNode(): Unit = {
     val x = new PyStringVariable("x", Map("x" -> "abcde") :: Map("x" -> "a") :: Map("x" -> "ab") :: Nil)


### PR DESCRIPTION
Scala's split behave different on edge case when separator is at the edge of the string.
Added correct behavior.